### PR TITLE
Update InstallDNVM.psm1

### DIFF
--- a/VSTS.DNX.Tasks.Shared/InstallDNVM.psm1
+++ b/VSTS.DNX.Tasks.Shared/InstallDNVM.psm1
@@ -60,7 +60,7 @@
                 "{0} {1}" -f
                     $(If(-Not [string]::IsNullOrWhiteSpace($dnxRuntime)){"-r $dnxRuntime"}),
                     $(If(-Not [string]::IsNullOrWhiteSpace($dnxArch)){"-a $dnxArch"})
-            )
+            ).Trim()
         }
     }
     else


### PR DESCRIPTION
Found an extra space if the dnxarch and/or dnxruntime is missing.
here's the error that i'm getting.

2016-04-23T03:17:39.0796156Z Calling: C:\agent\tasks\DNX.Tasks.BuildWebPackage\0.0.11\Tools\dnvm.ps1 install   1.0.0-rc1-update2 -Persistent
2016-04-23T03:17:39.2815908Z ##[error]A positional parameter cannot be found that accepts argument '1.0.0-rc1-update2'.
