### PR TITLE
Copy newNuget.config generated from "NuGet Installer" build step to handle custom feed authentication

### DIFF
--- a/VSTS.DNX.Tasks.BuildNugetPackage/BuildNugetPackage.ps1
+++ b/VSTS.DNX.Tasks.BuildNugetPackage/BuildNugetPackage.ps1
@@ -75,7 +75,7 @@ Function Main
 
     if (Test-Path $env:BUILD_SOURCESDIRECTORY\..\Nuget\newNuget.config)
     {
-		Write-Output "NuGet Installer step detected. Copying new Nuget.config."
+        Write-Output "NuGet Installer step detected. Copying new Nuget.config."
         Copy $env:BUILD_SOURCESDIRECTORY\..\Nuget\newNuget.config  $env:APPDATA\Nuget\Nuget.config
     }
 

--- a/VSTS.DNX.Tasks.BuildNugetPackage/BuildNugetPackage.ps1
+++ b/VSTS.DNX.Tasks.BuildNugetPackage/BuildNugetPackage.ps1
@@ -73,6 +73,12 @@ Function Main
         return
     }
 
+    if (Test-Path $env:BUILD_SOURCESDIRECTORY\..\Nuget\newNuget.config)
+    {
+		Write-Output "NuGet Installer step detected. Copying new Nuget.config."
+        Copy $env:BUILD_SOURCESDIRECTORY\..\Nuget\newNuget.config  $env:APPDATA\Nuget\Nuget.config
+    }
+
     Write-Output "$($projects.Count) Projects to build"
 
     Write-Output "dnu restore for:"


### PR DESCRIPTION
The "NuGet Installer" build step can be used to authenticate with custom NuGet feeds. However, it doesn't work with "dnu restore" unless you copy the generated newNuget.config file over the user's %APPDATA%\Nuget\Nuget.config file. This addition searches for that file and copies it over if it exists.

Note: I currently have the added lines below as a separate PowerShell task in my build (just before "DNX Tasks Build Web package" and it works. You'll probably want to test it yourself as well though.
